### PR TITLE
adjust RUBY_PLATFORM pattern for matching Windows 7

### DIFF
--- a/lib/gssapi/lib_gssapi.rb
+++ b/lib/gssapi/lib_gssapi.rb
@@ -30,7 +30,7 @@ module GSSAPI
       ffi_lib File.basename Dir.glob("/usr/lib/libgssapi_*").sort.first, FFI::Library::LIBC
     when /darwin/
       ffi_lib '/usr/lib/libgssapi_krb5.dylib', FFI::Library::LIBC
-    when /win/
+    when /mswin|mingw32|windows/
       ffi_lib 'gssapi32'  # Required the MIT Kerberos libraries to be installed
       ffi_convention :stdcall
     else


### PR DESCRIPTION
I have a customer who was seeing the following when using knife-windows on Windows 7 (which uses WinRM under the covers):

```
ERROR: LoadError: This platform (i386-mingw32) is not supported by ruby gssapi.
```

This was easily fixed by patch attached to this pull requrest.  I am now seeing the following error:

```
ERROR: TypeError: unable to resolve type 'size_t'
```

Not sure the best way to fix this one.
