### PR TITLE
support for 1.8.7

### DIFF
--- a/lib/gssapi/lib_gssapi.rb
+++ b/lib/gssapi/lib_gssapi.rb
@@ -32,8 +32,8 @@ module GSSAPI
     typedef :uint32, :OM_uint32
 
     class GssOID < FFI::Struct
-      layout  :length   =>  :OM_uint32,
-        :elements => :pointer # pointer of :void
+      layout :length, :OM_uint32,
+        :elements, :pointer # pointer of :void
 
       def self.gss_c_no_oid
         self.new(GSSAPI::LibGSSAPI::GSS_C_NO_OID)
@@ -72,8 +72,8 @@ module GSSAPI
     module GssBufferDescLayout
       def self.included(base)
         base.class_eval do
-          layout :length => :size_t,
-            :value  => :pointer # pointer of :void
+          layout :length, :size_t,
+            :value, :pointer # pointer of :void
 
           def length
             self[:length]
@@ -158,16 +158,16 @@ module GSSAPI
     #   iov_buff[:buffer][:length] = str.size
     #   iov_buff[:buffer][:value] = str
     class GssIOVBufferDesc < FFI::Struct
-      layout  :type   => :OM_uint32,
-              :buffer => UnManagedGssBufferDesc
+      layout :type, :OM_uint32,
+        :buffer, UnManagedGssBufferDesc
     end
 
     class GssChannelBindingsStruct < FFI::Struct
-      layout  :initiator_addrtype => :OM_uint32,
-        :initiator_address  => UnManagedGssBufferDesc,
-        :acceptor_addrtype  => :OM_uint32,
-        :acceptor_address   => UnManagedGssBufferDesc,
-        :application_data   => UnManagedGssBufferDesc
+      layout :initiator_addrtype, :OM_uint32,
+        :initiator_address, UnManagedGssBufferDesc,
+        :acceptor_addrtype, :OM_uint32,
+        :acceptor_address, UnManagedGssBufferDesc,
+        :application_data, UnManagedGssBufferDesc
 
       no_chn_bind = FFI::MemoryPointer.new :pointer  #
       no_chn_bind.write_int 0


### PR DESCRIPTION
Loading the gssapi gem in Ruby 1.8.7 throws the following error:

```
>> require 'gssapi'
RuntimeError: Ruby version not supported
        from /opt/ruby-1.8.7/lib/ruby/gems/1.8/gems/ffi-1.0.9/lib/ffi/struct.rb:261:in `hash_layout'
        from /opt/ruby-1.8.7/lib/ruby/gems/1.8/gems/ffi-1.0.9/lib/ffi/struct.rb:198:in `layout'
        from /opt/ruby-1.8.7/lib/ruby/gems/1.8/gems/gssapi-1.0.0/lib/gssapi/lib_gssapi.rb:36
        from /opt/ruby-1.8.7/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require'
        from /opt/ruby-1.8.7/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:31:in `require'
        from /opt/ruby-1.8.7/lib/ruby/gems/1.8/gems/gssapi-1.0.0/lib/gssapi.rb:30
        from /opt/ruby-1.8.7/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
        from /opt/ruby-1.8.7/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
        from (irb):1
```

FFI doesn't support using hashes with layout on 1.8.x due to issues
with the ordering of keys. This switches the layout calls to use
arrays, which are supported on 1.8.x, instead.
