### PR TITLE
Allow GssApiError to be initialized with string

### DIFF
--- a/lib/gssapi/exceptions.rb
+++ b/lib/gssapi/exceptions.rb
@@ -11,6 +11,14 @@ module GSSAPI
     def message; to_s + ": " + @s; end
 
     def initialize(maj_stat = nil, min_stat = nil)
+
+      # If raised as class (raise GssApiError, "msg) the error message is given
+      # as the first parameter.
+      if maj_stat.class == String
+        @s = maj_stat
+        return super maj_stat
+      end
+
       if(maj_stat.nil? && min_stat.nil?)
         @s = '(no error info)'
       else


### PR DESCRIPTION
All over the code GssApiError is raised like this:

``` ruby
raise GssApiError, "Message"
```

Which causes another exception to be raised in the initialize method which hides the real exception:

```
Exception `NoMethodError' at /home/opinsys/gssapi/lib/gssapi/exceptions.rb:21 - undefined method `read_uint32' for nil:NilClass
NoMethodError - undefined method `read_uint32' for nil:NilClass:
        /home/opinsys/gssapi/lib/gssapi/exceptions.rb:21:in `initialize'
        /home/opinsys/gssapi/lib/gssapi/simple.rb:105:in `exception'
        /home/opinsys/gssapi/lib/gssapi/simple.rb:105:in `raise'
        /home/opinsys/gssapi/lib/gssapi/simple.rb:105:in `accept_context'
        /home/opinsys/aatu3/aatu3.rb:27:in `block in <top (required)>'
        /home/opinsys/.rvm/gems/ruby-1.9.3-p194/gems/sinatra-1.3.2/lib/sinatra/base.rb:1212:in `call'
        ... SNIP ...
        /home/opinsys/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'
Exception `NoMethodError' at /home/opinsys/.rvm/gems/ruby-1.9.3-p194/gems/sinatra-1.3.2/lib/sinatra/base.rb:900 - undefined method `read_uint32' for nil:NilClass
```

This happens for example when you forget to call `acquire_credentials()` before `accept_context(in_token)`.
