### PR TITLE
Windows-only bug on library loading

### DIFF
--- a/lib/gssapi/lib_gssapi_loader.rb
+++ b/lib/gssapi/lib_gssapi_loader.rb
@@ -20,8 +20,10 @@ module GSSAPI
       case RUBY_PLATFORM
       when /linux/
         gssapi_lib = 'libgssapi_krb5.so.2'
+        ffi_lib gssapi_lib, FFI::Library::LIBC
       when /darwin/
         gssapi_lib = '/usr/lib/libgssapi_krb5.dylib'
+        ffi_lib gssapi_lib, FFI::Library::LIBC
       when /mswin|mingw32|windows/
         # Pull the gssapi32 path from the environment if it exist, otherwise use the default in Program Files
         gssapi32_path = ENV['gssapi32'] ? ENV['gssapi32'] : 'C:\Program Files (x86)\MIT\Kerberos\bin\gssapi32.dll'
@@ -30,7 +32,6 @@ module GSSAPI
       else
         raise LoadError, "This platform (#{RUBY_PLATFORM}) is not supported by ruby gssapi and the MIT libraries."
       end
-      ffi_lib gssapi_lib, FFI::Library::LIBC
 
       # -------------------- MIT Specifics -------------------- 
       attach_variable :__GSS_C_NT_HOSTBASED_SERVICE, :GSS_C_NT_HOSTBASED_SERVICE, :pointer # type gss_OID


### PR DESCRIPTION
Hi,

I hit an small issue using `gssapi` on Windows : ffi_lib is called with `nil` and produce a `LoadError` on `.dll`. This PR avoid the problem.

Thanks for your work on this.

Nicolas
