### PR TITLE
fix context double free

### DIFF
--- a/lib/gssapi/lib_gssapi.rb
+++ b/lib/gssapi/lib_gssapi.rb
@@ -158,7 +158,7 @@ module GSSAPI
 
       def self.release(ptr)
         if( ptr.address == 0 )
-          puts "NULL POINTER: Not freeing" if $DEBUG
+          puts "Releasing #{self.name} NULL POINTER: Not freeing" if $DEBUG
           return
         else
           puts "Releasing #{self.name} at #{ptr.address.to_s(16)}" if $DEBUG

--- a/lib/gssapi/simple.rb
+++ b/lib/gssapi/simple.rb
@@ -61,7 +61,7 @@ module GSSAPI
     #   to the remote host.  Otherwise it returns true and the GSS security context has been established.
     def init_context(in_token = nil, opts = {})
       min_stat = FFI::MemoryPointer.new :OM_uint32
-      ctx = (@context.nil? ? LibGSSAPI::GssCtxIdT.gss_c_no_context.address_of : @context.address_of)
+      pctx = (@context.nil? ? LibGSSAPI::GssCtxIdT.gss_c_no_context.address_of : @context.address_of)
       mech = LibGSSAPI::GssOID.gss_c_no_oid
       if(opts[:flags])
         flags = opts[:flags]
@@ -78,7 +78,7 @@ module GSSAPI
 
       maj_stat = LibGSSAPI.gss_init_sec_context(min_stat,
                                                 nil,
-                                                ctx,
+                                                pctx,
                                                 @int_svc_name,
                                                 mech,
                                                 flags,
@@ -91,8 +91,13 @@ module GSSAPI
                                                 nil)
 
       raise GssApiError.new(maj_stat, min_stat), "gss_init_sec_context did not return GSS_S_COMPLETE" if maj_stat > 1
-      
-      @context = LibGSSAPI::GssCtxIdT.new(ctx.get_pointer(0))
+
+      # The returned context may be equal to the passed in @context. If so, we
+      # must not create another AutoPointer to the same gss_buffer_t. If we do
+      # we will double delete it.
+      ctx = pctx.get_pointer(0)
+      @context = LibGSSAPI::GssCtxIdT.new(ctx) if ctx != @context
+
       maj_stat == 1 ? out_tok.value : true
     end
 
@@ -105,7 +110,7 @@ module GSSAPI
       raise GssApiError, "No credentials yet acquired. Call #{self.class.name}#acquire_credentials first" if @scred.nil?
 
       min_stat = FFI::MemoryPointer.new :OM_uint32
-      ctx = (@context.nil? ? LibGSSAPI::GssCtxIdT.gss_c_no_context.address_of : @context.address_of)
+      pctx = (@context.nil? ? LibGSSAPI::GssCtxIdT.gss_c_no_context.address_of : @context.address_of)
       no_chn_bind = LibGSSAPI::GSS_C_NO_CHANNEL_BINDINGS
       @client = FFI::MemoryPointer.new :pointer  # Will hold the initiating client name after the call
       mech = FFI::MemoryPointer.new :pointer  # Will hold the mech being used after the call
@@ -115,7 +120,7 @@ module GSSAPI
       ret_flags = FFI::MemoryPointer.new :OM_uint32
 
       maj_stat = LibGSSAPI.gss_accept_sec_context(min_stat,
-                                                  ctx,
+                                                  pctx,
                                                   @scred,
                                                   in_tok.pointer,
                                                   no_chn_bind,
@@ -127,7 +132,12 @@ module GSSAPI
 
       raise GssApiError.new(maj_stat, min_stat), "gss_accept_sec_context did not return GSS_S_COMPLETE" if maj_stat > 1
 
-      @context = LibGSSAPI::GssCtxIdT.new(ctx.get_pointer(0))
+      # The returned context may be equal to the passed in @context. If so, we
+      # must not create another AutoPointer to the same gss_buffer_t. If we do
+      # we will double delete it.
+      ctx = pctx.get_pointer(0)
+      @context = LibGSSAPI::GssCtxIdT.new(ctx) if ctx != @context
+
       out_tok.length > 0 ? out_tok.value : true
     end
 


### PR DESCRIPTION
In init_context and accept_context we were potentially creating multiple
GxxCtxIdT objects that pointed to the same gss_buffer_t. This could lead to a
double free and memory corruption (SEGV).

Additionally improve one log line that was helpful while debugging this issue.
