### PR TITLE
Switch to use rbconfig for platform detection, allowing support for JRuby

### DIFF
--- a/lib/gssapi/lib_gssapi_loader.rb
+++ b/lib/gssapi/lib_gssapi_loader.rb
@@ -17,7 +17,8 @@ module GSSAPI
 
 
     def self.load_mit
-      case RUBY_PLATFORM
+      host_os = RbConfig::CONFIG['host_os']
+      case host_os
       when /linux/
         gssapi_lib = 'libgssapi_krb5.so.2'
       when /darwin/
@@ -28,11 +29,11 @@ module GSSAPI
         ffi_lib gssapi32_path, FFI::Library::LIBC  # Required the MIT Kerberos libraries to be installed
         ffi_convention :stdcall
       else
-        raise LoadError, "This platform (#{RUBY_PLATFORM}) is not supported by ruby gssapi and the MIT libraries."
+        raise LoadError, "This host OS (#{host_os}) is not supported by ruby gssapi and the MIT libraries."
       end
       ffi_lib gssapi_lib, FFI::Library::LIBC
 
-      # -------------------- MIT Specifics -------------------- 
+      # -------------------- MIT Specifics --------------------
       attach_variable :__GSS_C_NT_HOSTBASED_SERVICE, :GSS_C_NT_HOSTBASED_SERVICE, :pointer # type gss_OID
       attach_variable :__GSS_C_NT_EXPORT_NAME, :GSS_C_NT_EXPORT_NAME, :pointer # type gss_OID
       LibGSSAPI.const_set("GSS_C_NT_HOSTBASED_SERVICE", __GSS_C_NT_HOSTBASED_SERVICE)
@@ -40,18 +41,19 @@ module GSSAPI
     end
 
     def self.load_heimdal
-      case RUBY_PLATFORM
+      host_os = RbConfig::CONFIG['host_os']
+      case host_os
       when /linux/
         gssapi_lib = 'libgssapi.so.3'
       when /darwin/
         # use Heimdal Kerberos since Mac MIT Kerberos is OLD. Do a "require 'gssapi/heimdal'" first
         gssapi_lib = '/usr/heimdal/lib/libgssapi.dylib'
       else
-        raise LoadError, "This platform (#{RUBY_PLATFORM}) is not supported by ruby gssapi and the Heimdal libraries."
+        raise LoadError, "This host OS (#{host_os}) is not supported by ruby gssapi and the Heimdal libraries."
       end
       ffi_lib gssapi_lib, FFI::Library::LIBC
 
-      # ------------------ Heimdal Specifics ------------------ 
+      # ------------------ Heimdal Specifics ------------------
       attach_variable :__gss_c_nt_hostbased_service_oid_desc, GssOID
       attach_variable :__gss_c_nt_export_name_oid_desc, GssOID
       LibGSSAPI.const_set("GSS_C_NT_HOSTBASED_SERVICE", FFI::Pointer.new(__gss_c_nt_hostbased_service_oid_desc.to_ptr))


### PR DESCRIPTION
JRuby, Rubinius and MRI all have full support for FFI but RUBY_PLATFORM doesn't do a good job of detecting the host OS (which is what it's actually being used for here) under some of those Ruby implementations.

This commit switches gssapi_loader to use RBConfig's host_os instead which will allow platforms like JRuby to make use of this gem as well.
