### PR TITLE
Implemented delegation and added verify_mic

### DIFF
--- a/lib/gssapi/lib_gssapi.rb
+++ b/lib/gssapi/lib_gssapi.rb
@@ -281,6 +281,9 @@ module GSSAPI
     # OM_uint32 gss_get_mic(OM_uint32 * minor_status, const gss_ctx_id_t context_handle, gss_qop_t qop_req, const gss_buffer_t input_message_buffer, gss_buffer_t output_message_buffer)
     attach_function :gss_get_mic, [:pointer, :pointer, :OM_uint32, :pointer, :pointer], :OM_uint32
 
+    # OM_uint32 gss_verify_mic (OM_uint32          *minor_status,const gss_ctx_id_t context_handle, const gss_buffer_t message_buffer,const gss_buffer_t token_buffer, gss_qop_t          qop_state)
+    attach_function :gss_verify_mic, [:pointer, :pointer, :pointer, :pointer, :OM_uint32], :OM_uint32
+
     # OM_uint32 gss_delete_sec_context(OM_uint32 * minor_status, gss_ctx_id_t * context_handle, gss_buffer_t output_token);
     attach_function :gss_delete_sec_context, [:pointer, :pointer, :pointer], :OM_uint32
 

--- a/test/spec/gssapi_simple_spec.rb
+++ b/test/spec/gssapi_simple_spec.rb
@@ -6,19 +6,65 @@ require 'yaml'
 
 describe GSSAPI::Simple, 'Test the Simple GSSAPI interface' do
 
-  before :all do
-    @conf = YAML.load_file "#{File.dirname(__FILE__)}/conf_file.yaml"
-  end
+  let(:conf) { YAML.load_file "#{File.dirname(__FILE__)}/conf_file.yaml" }
+  let(:cli) { GSSAPI::Simple.new(conf['s_host'], conf['s_service']) }
+  let(:srv ) { GSSAPI::Simple.new(conf['s_host'], conf['s_service'], conf['keytab']) }
 
   it 'should get the initial context for a client' do
-    gsscli = GSSAPI::Simple.new(@conf[:c_host], @conf[:c_service])
-    token = gsscli.init_context
-    token.should_not be_empty
+    token = cli.init_context
+    expect(token).not_to be_empty
   end
 
   it 'should acquire credentials for a server service' do
-    gsscli = GSSAPI::Simple.new(@conf[:s_host], @conf[:s_service], @conf[:keytab])
-    gsscli.acquire_credentials.should be_true
+    expect(srv.acquire_credentials).to eq(true)
   end
 
+  def play_handshake(cli,srv,clioptions={})
+    clitoken = cli.init_context(nil, clioptions)
+    expect(clitoken).not_to be_empty
+
+    expect(srv.acquire_credentials).to eq(true)
+
+    srvoktok = srv.accept_context(clitoken)
+    expect(srvoktok).not_to be_empty
+
+    ret = cli.init_context(srvoktok)
+    expect(ret).to eq(true)
+  end
+
+  it 'client server should handshake' do
+    play_handshake(cli,srv)
+  end
+
+  it 'mic' do
+    play_handshake(cli,srv)
+
+    secret = "this is secreta"
+
+    mic = cli.get_mic(secret)
+
+    expect(srv.verify_mic(secret,mic)).to eq(true)
+  end
+
+  context "no delegation" do
+    it "sets delegated_credentials to nil" do
+      play_handshake(cli,srv,:delegate => false)
+      expect(srv.delegated_credentials).to be_nil
+    end
+  end
+
+  describe "delegation" do
+    it "sets delegated_credentials to valid" do
+      play_handshake(cli,srv,:delegate => true)
+      expect(srv.delegated_credentials).not_to be_nil
+      delegated_display_name = srv.display_name
+
+      host2 = conf['s_host2'] || conf['s_host']
+      service2 = conf['s_service2'] || conf['s_service']
+      cli_del = GSSAPI::Simple.new(host2, service2)
+      srv_del = GSSAPI::Simple.new(host2, service2, conf['keytab2'])
+      play_handshake(cli_del,srv_del,:credentials => srv.delegated_credentials)
+      expect(srv_del.display_name).to eq(delegated_display_name)
+    end
+  end
 end

--- a/test/spec/test_buffer_spec.rb
+++ b/test/spec/test_buffer_spec.rb
@@ -10,6 +10,6 @@ describe GSSAPI::LibGSSAPI::UnManagedGssBufferDesc, 'Unmanaged Buffer Test' do
     end
 
     # If we get here without any errors we should be golden
-    true.should be_true
+    expect(true).to eq(true)
   end
 end


### PR DESCRIPTION
Simple:
- Added verify_mic to verify intergrity code generated by get_mic
- Added credentials option to init_context so delegate_credentials accepted by a server can be forwarded
- Improved specs to new expect syntax+added test for mic, handshake and delegation
