### PR TITLE
Fix corruption in iov_decrypt example

### DIFF
--- a/examples/gss_iov_helpers.rb
+++ b/examples/gss_iov_helpers.rb
@@ -47,7 +47,7 @@ module GssIOVHelpers
 
     len = str.unpack("L").first
     puts "LEN: #{len}"
-    iov_data = str.unpack("LA#{len}A*")
+    iov_data = str.unpack("La#{len}a*")
     iov0[:buffer].value = iov_data[1]
     iov1[:buffer].value = iov_data[2]
 


### PR DESCRIPTION
 - When breaking apart the given binary string response into length of header,
   header and payload - the incorrect value is given to Rubys unpack method.

   https://ruby-doc.org/core-2.3.0/String.html#method-i-unpack

   The directive 'A' is used:

   A | String | arbitrary binary string (remove trailing nulls and ASCII spaces)

   Since the given string is encrypted binary data, 'A' is the wrong directive
   given it performs removals.

   Instead, the directive 'a' should be used as it leaves all bytes intact:

   a | String | arbitrary binary string

 - Without this change, intermittent failures will occur as the decrypted
   messages will be nearly valid, but usually end with corrupt binary
   strings at the end of otherwise valid content like

   </s:Body></s\xB5f\xAF\x9B\xE5\x9B\xE9\xFE\xBB