### PR TITLE
use min_stat of 0 on error for set_keytab

### DIFF
--- a/lib/gssapi/simple.rb
+++ b/lib/gssapi/simple.rb
@@ -261,7 +261,11 @@ module GSSAPI
     # @param [String] keytab the path to the keytab
     def set_keytab(keytab)
       maj_stat = LibGSSAPI.krb5_gss_register_acceptor_identity(keytab)
-      raise GssApiError.new(maj_stat, min_stat), "krb5_gss_register_acceptor_identity did not return GSS_S_COMPLETE" if maj_stat != 0
+      if maj_stat != 0
+        min_stat = FFI::MemoryPointer.new :OM_uint32
+        min_stat.write_int(0)
+        raise GssApiError.new(maj_stat, min_stat), "krb5_gss_register_acceptor_identity did not return GSS_S_COMPLETE"
+      end
       true
     end
 


### PR DESCRIPTION
I looked at the MIT source and they just pass a min_stat of 0 when checking the error for `krb5_gss_register_acceptor_identity`. This mimics that behavior.