### PR TITLE
Avoid redefinition of struct layout

### DIFF
--- a/lib/gssapi/lib_gssapi_loader.rb
+++ b/lib/gssapi/lib_gssapi_loader.rb
@@ -7,8 +7,8 @@ module GSSAPI
   module LibGSSAPI
 
     class GssOID < FFI::Struct
-      layout  :length, :OM_uint32,
-        :elements, :pointer # pointer of :void
+      # pointer of :void
+      layout(:length, :OM_uint32, :elements, :pointer) unless defined? @layout
 
       def self.gss_c_no_oid
         self.new(GSSAPI::LibGSSAPI::GSS_C_NO_OID)


### PR DESCRIPTION
This adds a guard that prevents the redefinition of the
`GSSAPI::LibGSSAPI::GssOID` struct's layout. Previously, the class would
call the `layout` method and redefine the layout each time the class was
referenced. This behavior is deprecated in FFI >= 1.12.0 and will be
disallowed in FFI >= 2.0.

This fixes #34 